### PR TITLE
Allow the video directive in all types of builders

### DIFF
--- a/sphinxcontrib/video.py
+++ b/sphinxcontrib/video.py
@@ -64,9 +64,13 @@ def visit_video_node(self, node):
         )
     self.body.append(html_block)
 
-def depart_video_node(self, node):
+def visit_depart_video_null(self, node):
     pass
 
 def setup(app):
-    app.add_node(video, html=(visit_video_node, depart_video_node))
+    app.add_node(video, html=(visit_video_node, visit_depart_video_null))
+    app.add_node(video, latex=(visit_depart_video_null, visit_depart_video_null))
+    app.add_node(video, text=(visit_depart_video_null, visit_depart_video_null))
+    app.add_node(video, man=(visit_depart_video_null, visit_depart_video_null))
+    app.add_node(video, texinfo=(visit_depart_video_null, visit_depart_video_null))
     app.add_directive("video", Video)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
-pytest>=3.0,<4.0
+pytest>=6.0,<7.0
+sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-envlist = py{27,34,35,36,py},style
+envlist = py{27,34,35,36,38,310,py},style
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
@@ -31,3 +31,5 @@ commands =
 python =
   2.7: py27, style
   3.6: py36, mypy
+  3.8: py38, mypy
+  3.10: py310, mypy


### PR DESCRIPTION
We've added a couple of cases where it's not an HTML builder. What we want is just that the video output is ignored for now.